### PR TITLE
Release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 ﻿name: "Release"
-on: 
+on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 
 # NOTE: If your `project.godot` is at the repository root, set `PROJECT_PATH` below to ".".
 
@@ -18,22 +18,34 @@ jobs:
     container:
       image: barichello/godot-ci:4.4.1
     steps:
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           lfs: true
+
+      - name: Set up tag name
+        id: vars
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Update config/version in project.godot
+        run: |
+          sed -i 's/^config\/version=.*/config\/version="${TAG_NAME}"/' project.godot
+
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mkdir -v -p ~/.config/
           mv /root/.config/godot ~/.config/godot
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+          
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
           EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
           godot --headless --verbose --export-release "Windows Desktop" "$EXPORT_DIR/windows/$EXPORT_NAME.exe"
+          
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Augment the .github/workflows/release.yml workflow so that it releases a pushed tag (instead of every main branch) and rewrites the value of this project.godot config/version="" with the name of the tag before building

Enhances #93