### PR TITLE
Explosion affects blocks in chain reaction outward

### DIFF
--- a/global/config.gd
+++ b/global/config.gd
@@ -33,8 +33,9 @@ const PLAYER_SHIP_TARGET_ROTATION_FACTOR: float         = 10
 # blocks
 const BLOCK_ACTIVATION_HEAT_THRESHOLD: float = 0.5
 const BLOCK_BREAK_APART_VELOCITY: float      = 50
-const BLOCK_BREAK_HEAT_TRANSFER_RATIO: float = 0.9
-const BLOCK_EXPLOSION_OVERHEAT_RATIO: float  = 6 # exploson maxes at ratio above the amount of heat needed to break the block
+const BLOCK_BREAK_HALF_HEAT_TRANSFER_RATIO: float = 0.9
+const BLOCK_BREAK_QUART_HEAT_TRANSFER_RATIO: float = 0.9
+const BLOCK_EXPLOSION_OVERHEAT_RATIO: float  = 3 # exploson maxes at ratio above the amount of heat needed to break the block
 const BLOCK_HALF_BREAK_APART_VELOCITY: float = BLOCK_BREAK_APART_VELOCITY / 2
 const BLOCK_HALF_HEATED_BREAK_SEC: float     = BLOCK_HEATED_BREAK_SEC / 2
 const BLOCK_HEATED_BREAK_SEC: float          = 1.0
@@ -62,7 +63,7 @@ const PROJECTILE_EXPLOSIVE_MAX_VELOCITY: float     = 2000.0
 #
 # pertaining to explosive
 const EXPLOSION_FORCE: int                                       = 8000
-const EXPLOSION_HEAT_RADIUS_RATIO: float                         = 0.7
+const EXPLOSION_HEAT_RADIUS_RATIO: float                         = 0.6
 const EXPLOSION_LIFETIME_MSEC: int                               = 1000
 #
 # Board

--- a/global/util.gd
+++ b/global/util.gd
@@ -1,5 +1,8 @@
 extends Node
 
+# Signal that never happens, in case the tree is unloaded
+signal never
+
 # Get a color at a specific saturation ratio relative to the original color
 func color_at_sv_ratio(color: Color, s_ratio: float, v_ratio: float = 0) -> Color:
 	return Color.from_hsv(color.h, color.s * s_ratio, color.v * (v_ratio if v_ratio > 0 else s_ratio), color.a)
@@ -8,3 +11,11 @@ func color_at_sv_ratio(color: Color, s_ratio: float, v_ratio: float = 0) -> Colo
 # Get a color at a specific alpha ratio relative to the original color
 func color_at_alpha_ratio(color: Color, alpha_ratio: float) -> Color:
 	return Color(color.r, color.g, color.b, color.a * alpha_ratio)
+
+
+# Delay, guarding against the condition that the tree has been unloaded since the calling thread arrived here
+func delay(seconds: float) -> Signal:
+	if get_tree():
+		return get_tree().create_timer(seconds).timeout
+	else:
+		return never

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -58,6 +58,7 @@ func add_gem() -> void:
 	gem.freeze = true
 	gem.modulate.a = Config.BLOCK_INNER_GEM_ALPHA
 	self.add_child(gem)
+	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.GAME_START)
 	pass
 
 
@@ -79,8 +80,8 @@ func do_break() -> void:
 		gem.add_collision_exception_with(half2)
 	# Transfer heat to the broken pieces
 	if heat > 0:
-		half1.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
-		half2.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
+		half1.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HALF_HEAT_TRANSFER_RATIO)
+		half2.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HALF_HEAT_TRANSFER_RATIO)
 	# Add the halves to the scene
 	self.get_parent().add_child(half2)
 	self.get_parent().add_child(half1)

--- a/models/block/block_half.gd
+++ b/models/block/block_half.gd
@@ -39,8 +39,8 @@ func do_break() -> void:
 	self.get_parent().add_child(quartB)
 	# Transfer heat to the broken pieces
 	if heat > 0:
-		quartA.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
-		quartB.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_HEAT_TRANSFER_RATIO)
+		quartA.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_QUART_HEAT_TRANSFER_RATIO)
+		quartB.apply_heat(heat * 0.5 * Config.BLOCK_BREAK_QUART_HEAT_TRANSFER_RATIO)
 	# Remove the block from the scene
 	self.call_deferred("queue_free")
 	pass

--- a/models/explosive/explosion.gd
+++ b/models/explosive/explosion.gd
@@ -25,6 +25,7 @@ func _ready() -> void:
 	else:
 		push_error("No color found for player ", player_num)
 	$ParticleEmitter.emitting = true
+	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.PROJECTILE_IMPACT)
 
 
 # Called at a fixed rate. 'delta' is the elapsed time since the previous frame.

--- a/models/explosive/explosion.gd
+++ b/models/explosive/explosion.gd
@@ -8,10 +8,11 @@ extends Node2D
 @export var player_num: int = 0
 
 # Variables
-var instantiated_at_ticks_msec: float = 0.0
+var instantiated_at_ticks_msec: int = 0
 var explosive_radius: float           = 0.0
 var heat_radius: float                = 0.0
-var exploded: bool = false
+var exploded: bool                    = false
+var affected_bodies: Dictionary[int, Array] = {}
 
 
 # Called when the node enters the scene tree for the first time.
@@ -30,21 +31,50 @@ func _ready() -> void:
 
 # Called at a fixed rate. 'delta' is the elapsed time since the previous frame.
 func _physics_process(_delta: float) -> void:
+	if affected_bodies.size() > 0:
+		var now_at_msec: int = Time.get_ticks_msec() - instantiated_at_ticks_msec
+		for at_msec in affected_bodies.keys():
+			# If the time has come to apply effects to the bodies
+			if now_at_msec >= at_msec:
+				for item in affected_bodies[at_msec]:
+					_apply_to_body(item)
+				affected_bodies.erase(at_msec)
+
 	if Time.get_ticks_msec() - instantiated_at_ticks_msec > Config.EXPLOSION_LIFETIME_MSEC:
 		queue_free()
 		return
-		
+
+	# If already exploded, don't process further
 	if exploded:
-		return  # If already exploded, do nothing
-		
+		return
+
 	# Process all bodies in the collision area
 	for body in explosive_area.get_overlapping_bodies():
+		exploded = true  # Mark as exploded
 		var diff: Vector2   = (body.position - position)
 		var distance: float = diff.length()
-		body.apply_central_force(diff.normalized() * Config.EXPLOSION_FORCE * (1 - distance / explosive_radius))
-		const max_heat = Config.BLOCK_HEATED_BREAK_SEC * Config.BLOCK_EXPLOSION_OVERHEAT_RATIO
-		if body is Block or body is BlockHalf or body is BlockQuart or body is Ship:
-			if distance <= heat_radius:
-				body.apply_heat(max_heat * exp(-distance / heat_radius * 3))
-				exploded = true  # Mark as exploded
-		
+		var dir: Vector2    = diff.normalized()
+		var at_msec: int    = floori(pow(distance/explosive_radius, 2) * Config.EXPLOSION_LIFETIME_MSEC)
+		if at_msec not in affected_bodies:
+			affected_bodies[at_msec] = []
+		var item: Dictionary = {}
+		item.body     = body
+		item.dir      = dir
+		item.distance = distance
+		affected_bodies[at_msec].append(item)
+
+
+# Apply explosion effects to the body based on distance
+func _apply_to_body(item: Dictionary) -> void:
+	var body     = item.body
+	var dir      = item.dir
+	var distance = item.distance
+	if not body:
+		return  # Ensure body is valid before proceeding
+	body.apply_central_force(dir * Config.EXPLOSION_FORCE * (1-pow(distance / explosive_radius , 2)))
+	const max_heat = Config.BLOCK_HEATED_BREAK_SEC * Config.BLOCK_EXPLOSION_OVERHEAT_RATIO
+	if body is Block or body is BlockHalf or body is BlockQuart or body is Ship:
+		if distance <= heat_radius:
+			body.apply_heat(max_heat * (1-pow(-distance / heat_radius, 2)))
+
+			

--- a/models/explosive/projectile_explosive.gd
+++ b/models/explosive/projectile_explosive.gd
@@ -3,7 +3,6 @@ extends Collidable
 
 # Preloaded scene for the explosion effect
 const explosion_scene: PackedScene = preload("res://models/explosive/explosion.tscn")
-
 # Player number to identify the projectile
 @export var player_num: int = 0
 
@@ -19,12 +18,12 @@ func _ready() -> void:
 
 	# Connect the Collision to the on-collision function
 	connect("body_entered", _on_body_entered)
-	
+
 	# Count this projectile
 	Game.projectiles_in_play += 1
 	Game.projectile_count_updated.emit()
 	pass
-	
+
 
 # Called when the projectile is removed from the stage
 func _exit_tree() -> void:
@@ -39,7 +38,6 @@ func _on_body_entered(_other: Node) -> void:
 	explosion.position = position
 	explosion.player_num = player_num
 	self.get_parent().call_deferred("add_child", explosion)
-	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.PROJECTILE_IMPACT)
 	# Remove this projectile from the stage
 	self.queue_free()
 	pass

--- a/models/player/ship.gd
+++ b/models/player/ship.gd
@@ -78,7 +78,7 @@ func do_enable() -> void:
 
 
 # Apply heat if not disabled
-func apply_heat(delta: float, heated_by: Node2D = null) -> void:
+func apply_heat(delta: float) -> void:
 	if is_disabled:
 		return
 	heated_delta += delta

--- a/models/player/ship.tscn
+++ b/models/player/ship.tscn
@@ -11,7 +11,6 @@ _data = [Vector2(0.0170455, 0), 0.0, 0.0, 0, 0, Vector2(0.539773, 1), 0.0, 0.0, 
 point_count = 3
 
 [node name="Ship" type="RigidBody2D"]
-position = Vector2(3, 0)
 collision_priority = 2.0
 mass = 10.0
 physics_material_override = ExtResource("1_3lbs4")

--- a/scenes/explosion_test.gd
+++ b/scenes/explosion_test.gd
@@ -3,21 +3,19 @@ extends Node2D
 # Preloaded Scenes
 const block_scene: PackedScene     = preload('res://models/block/block.tscn')
 const explosion_scene: PackedScene = preload('res://models/explosive/explosion.tscn')
-# Signal that never happens, in case the tree is unloaded
-signal never
 
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	_create_board()
-	await _delay(1.0)
-	# Spawn an explosion at the center of the board
 	var viewport_size: Vector2 = get_viewport().get_visible_rect().size
-	var explosion: Node        = explosion_scene.instantiate()
-	explosion.position = Vector2(viewport_size.x / 2, viewport_size.y / 2)
-	explosion.player_num = 1
-	self.add_child(explosion)
-	await _delay(5.0)
+	_create_board()
+	await Util.delay(1.0)
+	await _spawn_explosion(viewport_size.x / 2, viewport_size.y / 2)
+	await Util.delay(2.0)
+	await _spawn_explosion(viewport_size.x / 2, viewport_size.y / 2)
+	await Util.delay(2.0)
+	await _spawn_random_explosions(5, 1)
+	await _spawn_random_explosions(25, 0.1)
 	_goto_scene("res://scenes/explosion_test.tscn")
 	pass
 
@@ -28,14 +26,28 @@ func _create_board() -> void:
 		for y in range(Config.BOARD_GRID_ROWS):
 			_spawn_block(_grid_position(x, y))
 
-
-# Delay, guarding against the condition that the tree has been unloaded since the calling thread arrived here
-func _delay(seconds: float) -> Signal:
-	if get_tree():
-		return get_tree().create_timer(seconds).timeout
-	else:
-		return never
-
+			
+# Spawn a random number of explosions at random positions on the board		
+func _spawn_random_explosions(num: int, delay: float) -> Signal:
+	var viewport_size: Vector2 = get_viewport().get_visible_rect().size
+	for i in range(num):
+		var x: float = randf() * viewport_size.x
+		var y: float = randf() * viewport_size.y
+		await _spawn_explosion(x, y)
+		await Util.delay(delay)  # Delay between explosions to avoid too many at once
+	return Util.delay(0)
+	
+	
+		
+# Spawn an explosion at the center of the board
+func _spawn_explosion(x: float, y:float) -> Signal:
+	var explosion: Node        = explosion_scene.instantiate()
+	explosion.position = Vector2(x,y)
+	explosion.player_num = 1
+	self.add_child(explosion)
+	return Util.delay(0)
+		
+	
 
 func _grid_position(x: int, y: int) -> Vector2:
 	# Convert grid coordinates to world coordinates

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,8 +1,5 @@
 extends Node2D
 
-# Signal that never happens, in case the tree is unloaded
-signal never
-
 # Constants
 const GAME_START_DELAY_SECONDS: float = 1.0
 
@@ -15,7 +12,7 @@ func _ready() -> void:
 # If both players are ready, start the game
 func _on_player_ready_updated() -> void:
 	if $ReadyPlayer1.is_ready and $ReadyPlayer2.is_ready:
-		await _delay(GAME_START_DELAY_SECONDS)
+		await Util.delay(GAME_START_DELAY_SECONDS)
 		if $ReadyPlayer1.is_ready and $ReadyPlayer2.is_ready:
 			_goto_scene("res://scenes/play_game.tscn")
 
@@ -26,9 +23,3 @@ func _goto_scene(path: String) -> void:
 		get_tree().change_scene_to_file(path)
 
 
-# Delay, guarding against the condition that the tree has been unloaded since the calling thread arrived here
-func _delay(seconds: float) -> Signal:
-	if get_tree():
-		return get_tree().create_timer(seconds).timeout
-	else:
-		return never

--- a/scenes/play_game.gd
+++ b/scenes/play_game.gd
@@ -17,8 +17,6 @@ var started_at_ticks_msec: int           = 0
 var spawn_next_gem_at_msec: int          = 0
 var gem_dont_spawn_until_ticks_msec: int = 0
 var is_game_over: bool                   = false
-# Signal that never happens, in case the tree is unloaded
-signal never
 
 
 # Called when the node enters the scene tree for the first time.
@@ -34,11 +32,10 @@ func _ready() -> void:
 	Game.projectile_count_updated.connect(_check_for_game_over)
 	Game.player_did_collect_gem.connect(_on_player_collect_gem)
 	# Countdown and then start the game
-	AudioManager.create_audio(SoundEffectSetting.SOUND_EFFECT_TYPE.GAME_START)
 	_show_modal("Ready...", Config.BOARD_MODAL_NEUTRAL_TEXT_COLOR)
-	await _delay(Config.GAME_START_COUNTER_DELAY)
+	await Util.delay(Config.GAME_START_COUNTER_DELAY)
 	_show_modal("Set...", Config.BOARD_MODAL_NEUTRAL_TEXT_COLOR)
-	await _delay(Config.GAME_START_COUNTER_DELAY)
+	await Util.delay(Config.GAME_START_COUNTER_DELAY)
 	_hide_modal()
 	pass
 
@@ -57,7 +54,7 @@ func _game_over(result: Game.Result) -> void:
 	if is_game_over:
 		return
 	is_game_over = true
-	await _delay(Config.GAME_OVER_DELAY_SEC)
+	await Util.delay(Config.GAME_OVER_DELAY_SEC)
 	match result:
 		Game.Result.PLAYER_1_WINS:
 			_show_modal("Player 1 wins!", Config.PLAYER_COLORS[1][0])
@@ -65,7 +62,7 @@ func _game_over(result: Game.Result) -> void:
 			_show_modal("Player 2 wins!", Config.PLAYER_COLORS[2][0])
 		Game.Result.DRAW:
 			_show_modal("Draw!", Config.BOARD_MODAL_NEUTRAL_TEXT_COLOR)
-	await _delay(Config.GAME_OVER_SHOW_MODAL_SEC)
+	await Util.delay(Config.GAME_OVER_SHOW_MODAL_SEC)
 	_hide_modal()
 	_goto_scene('res://scenes/main.tscn')
 	pass
@@ -223,14 +220,6 @@ func _spawn_gem() -> void:
 func _goto_scene(path: String) -> void:
 	if get_tree():
 		get_tree().change_scene_to_file(path)
-
-
-# Delay, guarding against the condition that the tree has been unloaded since the calling thread arrived here
-func _delay(seconds: float) -> Signal:
-	if get_tree():
-		return get_tree().create_timer(seconds).timeout
-	else:
-		return never
 
 
 # Pause game, guarding against the condition that the tree has been unloaded since the calling thread arrived here


### PR DESCRIPTION
- Explosion triggers audio (not projectile)
- Game start sound on each gem spawn (not start of game)
- When explosion occurs, don't immediately affect bodies. Create an array of affect bodies and then process during the physics cycle
- Explosive effect tuning

Closes #111