### PR TITLE
Playable on couch console with dual gamepads

### DIFF
--- a/.github/nothing_left_todo.sh
+++ b/.github/nothing_left_todo.sh
@@ -11,6 +11,6 @@ check() {
   fi
 }
 
-# Check that there are no TODO items in the specified directories
+# Check the specified directories
 check global
 check models

--- a/global/config.gd
+++ b/global/config.gd
@@ -93,14 +93,3 @@ const BOARD_SEED_F3: int                    = 973_523_665
 const BOARD_SEED_F4: int                    = 167_653_873
 const BOARD_SEED_F5: int                    = 423_587_300
 const BOARD_SEED_F6: int                    = 798_647_400
-#
-# Formatting template for player input
-const player_input_mapping_format: Dictionary = {
-													"left": "p%d_left",
-													"right": "p%d_right",
-													"up": "p%d_up",
-													"down": "p%d_down",
-													"action_a": "p%d_action_a",
-													"action_b": "p%d_action_b",
-													"start": "p%d_start",
-												}

--- a/global/config.gd
+++ b/global/config.gd
@@ -1,3 +1,5 @@
+extends Node
+
 #
 # This is a dictionary of player colors, where the key is the player ID and the value is an array of two colors.
 const PLAYER_COLORS: Dictionary = {

--- a/global/game.gd
+++ b/global/game.gd
@@ -9,6 +9,7 @@ signal player_did_harm(player_num: int)
 signal projectile_count_updated
 signal player_ready_updated
 signal player_laser_charge_updated(player_num: int, charge_sec: float)
+signal input_mode_updated
 # Group names
 const BLOCK_GROUP: StringName = "BlockGroup"
 const GEM_GROUP: StringName   = "GemGroup"
@@ -17,6 +18,11 @@ enum Result {
 	PLAYER_1_WINS,
 	PLAYER_2_WINS,
 	DRAW,
+}
+# Enum for input modes
+enum InputMode {
+	ARCADE_TABLE,
+	CONSOLE_GAMEPADS,
 }
 
 # Keeping track of the score
@@ -30,6 +36,8 @@ enum Result {
 # Keeping track of the projectile count
 @onready var projectiles_in_play: int = 0
 
+# Keep track of the input mode
+@onready var input_mode: InputMode = InputMode.ARCADE_TABLE
 
 # Check if the player can launch a projectile
 func player_can_launch_projectile(player_num: int) -> bool:
@@ -39,6 +47,14 @@ func player_can_launch_projectile(player_num: int) -> bool:
 		push_error("No score found for player_num: ", player_num)
 		return false
 
+
+# Activate dual gamepad input mode, issue #126
+func activate_dual_gamepad_input_mode() -> void:
+	print ("[GAME] Activating dual gamepad input mode")
+	input_mode = InputMode.CONSOLE_GAMEPADS
+	input_mode_updated.emit()
+	pass
+	
 
 func _ready() -> void:
 	reset_game.connect(_do_reset_game)

--- a/global/game.gd
+++ b/global/game.gd
@@ -21,8 +21,8 @@ enum Result {
 }
 # Enum for input modes
 enum InputMode {
-	ARCADE_TABLE,
-	CONSOLE_GAMEPADS,
+	TABLE,
+	COUCH,
 }
 
 # Keeping track of the score
@@ -37,7 +37,7 @@ enum InputMode {
 @onready var projectiles_in_play: int = 0
 
 # Keep track of the input mode
-@onready var input_mode: InputMode = InputMode.ARCADE_TABLE
+@onready var input_mode: InputMode = InputMode.TABLE
 
 # Check if the player can launch a projectile
 func player_can_launch_projectile(player_num: int) -> bool:
@@ -46,15 +46,18 @@ func player_can_launch_projectile(player_num: int) -> bool:
 	else:
 		push_error("No score found for player_num: ", player_num)
 		return false
+		
 
-
-# Activate dual gamepad input mode, issue #126
-func activate_dual_gamepad_input_mode() -> void:
-	print ("[GAME] Activating dual gamepad input mode")
-	input_mode = InputMode.CONSOLE_GAMEPADS
+# Detect the input mode based on the current input devices, see #126
+func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
+	if Input.get_connected_joypads().size() >= 2:
+		print ("[GAME] Activating dual gamepad input mode")
+		input_mode = InputMode.COUCH
+	else:
+		print ("[GAME] Activating single gamepad input mode")
+		input_mode = InputMode.TABLE
 	input_mode_updated.emit()
-	pass
-	
+
 
 func _ready() -> void:
 	reset_game.connect(_do_reset_game)
@@ -64,6 +67,7 @@ func _ready() -> void:
 	projectile_count_updated.connect(_on_projectile_count_updated)
 	player_ready_updated.connect(_on_player_ready_updated)
 	player_laser_charge_updated.connect(_on_player_laser_charge_updated)
+	Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
 
 func _do_reset_game() -> void:

--- a/global/game.gd
+++ b/global/game.gd
@@ -9,7 +9,6 @@ signal player_did_harm(player_num: int)
 signal projectile_count_updated
 signal player_ready_updated
 signal player_laser_charge_updated(player_num: int, charge_sec: float)
-signal input_mode_updated
 # Group names
 const BLOCK_GROUP: StringName = "BlockGroup"
 const GEM_GROUP: StringName   = "GemGroup"
@@ -19,12 +18,6 @@ enum Result {
 	PLAYER_2_WINS,
 	DRAW,
 }
-# Enum for input modes
-enum InputMode {
-	TABLE,
-	COUCH,
-}
-
 # Keeping track of the score
 @onready var score: Dictionary = {
 									 1: 0,
@@ -36,9 +29,6 @@ enum InputMode {
 # Keeping track of the projectile count
 @onready var projectiles_in_play: int = 0
 
-# Keep track of the input mode
-@onready var input_mode: InputMode = InputMode.TABLE
-
 # Check if the player can launch a projectile
 func player_can_launch_projectile(player_num: int) -> bool:
 	if score.has(player_num):
@@ -48,17 +38,6 @@ func player_can_launch_projectile(player_num: int) -> bool:
 		return false
 		
 
-# Detect the input mode based on the current input devices, see #126
-func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
-	if Input.get_connected_joypads().size() >= 2:
-		print ("[GAME] Activating dual gamepad input mode")
-		input_mode = InputMode.COUCH
-	else:
-		print ("[GAME] Activating single gamepad input mode")
-		input_mode = InputMode.TABLE
-	input_mode_updated.emit()
-
-
 func _ready() -> void:
 	reset_game.connect(_do_reset_game)
 	player_did_launch_projectile.connect(_on_player_launch_projectile)
@@ -67,7 +46,6 @@ func _ready() -> void:
 	projectile_count_updated.connect(_on_projectile_count_updated)
 	player_ready_updated.connect(_on_player_ready_updated)
 	player_laser_charge_updated.connect(_on_player_laser_charge_updated)
-	Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
 
 func _do_reset_game() -> void:

--- a/global/input_manager.gd
+++ b/global/input_manager.gd
@@ -1,0 +1,29 @@
+﻿extends Node
+
+# Signals
+signal input_mode_updated
+# Enum for input modes
+enum Mode {
+	TABLE,
+	COUCH,
+}
+# Keep track of the input mode
+@onready var mode: Mode = Mode.TABLE
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	Input.joy_connection_changed.connect(_on_joy_connection_changed)
+
+
+# Detect the input mode based on the current input devices, see #126
+func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
+	if Input.get_connected_joypads().size() >= 2:
+		print ("[GAME] Activating dual gamepad input mode")
+		mode = Mode.COUCH
+	else:
+		print ("[GAME] Activating single gamepad input mode")
+		mode = Mode.TABLE
+	input_mode_updated.emit()
+
+

--- a/global/input_manager.gd
+++ b/global/input_manager.gd
@@ -11,9 +11,12 @@ enum Mode {
 @onready var mode: Mode = Mode.TABLE
 
 
-# Called when the node enters the scene tree for the first time.
+# --- Lifecycle -----------------------------------------------------------
+
 func _ready() -> void:
+	# hot-plug support
 	Input.joy_connection_changed.connect(_on_joy_connection_changed)
+	_assign_gamepads()
 
 
 # Detect the input mode based on the current input devices, see #126
@@ -25,5 +28,134 @@ func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
 		print ("[GAME] Activating single gamepad input mode")
 		mode = Mode.TABLE
 	input_mode_updated.emit()
+	_assign_gamepads()
 
 
+signal move(player: int, dir: Vector2)                 # per-frame movement vector
+signal action_pressed(player: int, action: String)     # e.g., "fire", "start"
+signal action_released(player: int, action: String)
+# --- Config --------------------------------------------------------------
+
+# Deadzone for sticks
+const DEADZONE := 0.25
+# Axes (0=X, 1=Y on most devices; customize if needed)
+const AXIS_LEFT_X := 0
+const AXIS_LEFT_Y := 1
+# Map joypad buttons → abstract actions (adjust to your liking)
+# 0=A 1=B 2=X 3=Y 6=BACK 7=START on XInput; tweak for your target
+const JOY_TO_ACTION := {
+						   0: "fire",
+						   7: "start"
+					   }
+# Keyboard action names that already exist in your Input Map
+const P1_KEYS := {
+					 "left": "p1_left",
+					 "right": "p1_right",
+					 "up": "p1_up",
+					 "down": "p1_down",
+					 "fire": "p1_fire",
+					 "start": "p1_start"
+				 }
+const P2_KEYS := {
+					 "left": "p2_left",
+					 "right": "p2_right",
+					 "up": "p2_up",
+					 "down": "p2_down",
+					 "fire": "p2_fire",
+					 "start": "p2_start"
+				 }
+# --- State ---------------------------------------------------------------
+
+var p1_device_id: int = -1   # -1 = no gamepad (uses keyboard)
+var p2_device_id: int = -1
+
+
+func _physics_process(_delta: float) -> void:
+	# Player 1 movement
+	var p1_dir := _get_dir_for_player(1)
+	emit_signal("move", 1, p1_dir)
+	# Player 2 movement
+	var p2_dir := _get_dir_for_player(2)
+	emit_signal("move", 2, p2_dir)
+
+
+func _input(event: InputEvent) -> void:
+	# Route joypad events by device id → player index
+	if event is InputEventJoypadButton:
+		var player := _player_for_device(event.device)
+		if player != 0:
+			if event.pressed and not event.is_echo():
+				if JOY_TO_ACTION.has(event.button_index):
+					emit_signal("action_pressed", player, JOY_TO_ACTION[event.button_index])
+			else:
+				if JOY_TO_ACTION.has(event.button_index):
+					emit_signal("action_released", player, JOY_TO_ACTION[event.button_index])
+			get_viewport().set_input_as_handled()
+			return
+
+	# Keyboard: only for players that DON'T have a gamepad
+	if event is InputEventKey and not event.is_echo():
+		# P1 keyboard actions
+		if p1_device_id == -1:
+			_handle_keyboard_action_event(1, event, P1_KEYS)
+		# P2 keyboard actions
+		if p2_device_id == -1:
+			_handle_keyboard_action_event(2, event, P2_KEYS)
+
+
+# --- Helpers -------------------------------------------------------------
+
+func _get_dir_for_player(player: int) -> Vector2:
+	# If player has a gamepad, read stick; otherwise, read keyboard axes.
+	var dev := p1_device_id if player == 1 else p2_device_id
+	if dev != -1:
+		var x := Input.get_joy_axis(dev, AXIS_LEFT_X)
+		var y := Input.get_joy_axis(dev, AXIS_LEFT_Y)
+		var v := Vector2(x, y)
+		# invert Y if you want up to be negative stick Y (depends on your game)
+		if v.length() < DEADZONE:
+			return Vector2.ZERO
+		return v
+	else:
+		var keys   := P1_KEYS if player == 1 else P2_KEYS
+		var x_axis := Input.get_action_strength(keys["right"]) - Input.get_action_strength(keys["left"])
+		var y_axis := Input.get_action_strength(keys["down"]) - Input.get_action_strength(keys["up"])
+		var v      := Vector2(x_axis, y_axis)
+		return v.normalized() if v.length() > 1.0 else v
+
+
+func _player_for_device(device_id: int) -> int:
+	if device_id == p1_device_id:
+		return 1
+	if device_id == p2_device_id:
+		return 2
+	return 0
+
+
+func _assign_gamepads() -> void:
+	var devices := Input.get_connected_joypads()
+	devices.sort()  # lowest id first for stability
+	# Optionally: dedupe "ghost" XInput mirrors by GUID/name here.
+
+	p1_device_id = -1
+	p2_device_id = -1
+	if devices.size() >= 1:
+		p1_device_id = devices[0]
+	if devices.size() >= 2:
+		p2_device_id = devices[1]
+
+
+# If only one pad, P2 stays -1 and uses keyboard.
+
+func _handle_keyboard_action_event(player: int, event: InputEventKey, keys: Dictionary) -> void:
+	# Map key events to abstract actions; movement is polled each frame separately.
+	if event.pressed:
+		if event.is_action_pressed(keys["fire"]):
+			emit_signal("action_pressed", player, "fire")
+		if event.is_action_pressed(keys["start"]):
+			emit_signal("action_pressed", player, "start")
+	else:
+		if event.is_action_released(keys["fire"]):
+			emit_signal("action_released", player, "fire")
+		if event.is_action_released(keys["start"]):
+			emit_signal("action_released", player, "start")

--- a/global/input_manager.gd
+++ b/global/input_manager.gd
@@ -114,26 +114,25 @@ func _input(event: InputEvent) -> void:
 					return
 
 
-# --- Helpers -------------------------------------------------------------
-
+# If player has a gamepad, read stick; otherwise, read keyboard axes.
 func _get_dir_for_player(player: int) -> Vector2:
-
-	# If player has a gamepad, read stick; otherwise, read keyboard axes.
-	var dev := p1_device_id if player == 1 else p2_device_id
-	if dev != -1:
-		var x := Input.get_joy_axis(dev, JoyAxis.JOY_AXIS_LEFT_X)
-		var y := Input.get_joy_axis(dev, JoyAxis.JOY_AXIS_LEFT_Y)
-		var v := Vector2(x, y)
-		# invert Y if you want up to be negative stick Y (depends on your game)
-		if v.length() < DEADZONE:
-			return Vector2.ZERO
-		return v
-	else:
-		var keys   := P1_KEYS if player == 1 else P2_KEYS
-		var x_axis := Input.get_action_strength(keys[INPUT_RIGHT]) - Input.get_action_strength(keys[INPUT_LEFT])
-		var y_axis := Input.get_action_strength(keys[INPUT_DOWN]) - Input.get_action_strength(keys[INPUT_UP])
-		var v      := Vector2(x_axis, y_axis)
-		return v.normalized() if v.length() > 1.0 else v
+	match mode:
+		Mode.TABLE:
+			var keys   := P1_KEYS if player == 1 else P2_KEYS
+			var x_axis := Input.get_action_strength(keys[INPUT_RIGHT]) - Input.get_action_strength(keys[INPUT_LEFT])
+			var y_axis := Input.get_action_strength(keys[INPUT_DOWN]) - Input.get_action_strength(keys[INPUT_UP])
+			var v      := Vector2(x_axis, y_axis)
+			return v.normalized() if v.length() > 1.0 else v
+		Mode.COUCH:
+			var dev := p1_device_id if player == 1 else p2_device_id
+			var x   := Input.get_joy_axis(dev, JoyAxis.JOY_AXIS_LEFT_X)
+			var y   := Input.get_joy_axis(dev, JoyAxis.JOY_AXIS_LEFT_Y)
+			var v   := Vector2(x, y)
+			# invert Y if you want up to be negative stick Y (depends on your game)
+			if v.length() < DEADZONE:
+				return Vector2.ZERO
+			return v
+	return Vector2.ZERO
 
 
 func _player_for_device(device_id: int) -> int:

--- a/global/input_manager.gd.uid
+++ b/global/input_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://cvkc2vpma6dny

--- a/models/player/instructions.tscn
+++ b/models/player/instructions.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=4 format=3 uid="uid://5830e5k6edcl"]
+
+[ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_gcy31"]
+[ext_resource type="FontFile" uid="uid://bm8bvpfu88aux" path="res://assets/fonts/Montserrat/static/Montserrat-Regular.ttf" id="3_3jflg"]
+[ext_resource type="FontFile" uid="uid://csk5t783aicvv" path="res://assets/fonts/Montserrat/static/Montserrat-ExtraBoldItalic.ttf" id="4_rutte"]
+
+[node name="Score" type="Node2D"]
+
+[node name="GameTitleText" type="RichTextLabel" parent="."]
+offset_left = -213.0
+offset_top = -9.0
+offset_right = 212.0
+offset_bottom = 63.0
+theme_override_fonts/normal_font = ExtResource("2_gcy31")
+theme_override_font_sizes/normal_font_size = 40
+text = "BLOCKBUSTERS!"
+horizontal_alignment = 1
+
+[node name="InstructionsText" type="RichTextLabel" parent="."]
+offset_left = -255.0
+offset_top = 73.0
+offset_right = 359.0
+offset_bottom = 204.0
+theme_override_fonts/normal_font = ExtResource("3_3jflg")
+theme_override_font_sizes/normal_font_size = 18
+text = "- Launch a projectile, costs 1 point
+- Blow up the blocks containing gems to free the gems
+- Get a freed gem to your zone, collect it for +2 points
+- Projectile hits a ship, disables it for 3 seconds
+- First player to 10 points wins"
+
+[node name="ReadyText" type="RichTextLabel" parent="."]
+offset_left = -351.0
+offset_top = 230.0
+offset_right = 342.0
+offset_bottom = 275.0
+theme_override_fonts/normal_font = ExtResource("4_rutte")
+theme_override_font_sizes/normal_font_size = 18
+text = "Press start to ready up!"
+horizontal_alignment = 1

--- a/models/player/ready.gd
+++ b/models/player/ready.gd
@@ -8,10 +8,6 @@ const UNREADY_COLOR_SV_RATIO: float = 0.3
 @export var player_num: int = 0
 # When the player is ready
 @export var is_ready: bool = false
-# Input mapping
-var input_mapping: Dictionary = {
-									"start": "ui_cancel",
-								}
 
 
 
@@ -20,14 +16,8 @@ var input_mapping: Dictionary = {
 func _ready() -> void:
 	_set_player_name()
 	_set_color()
-	# Set up input mapping for player
-	for key in input_mapping.keys():
-		var action_name: String = Config.player_input_mapping_format[key] % player_num
-		if InputMap.has_action(action_name):
-			input_mapping[key] = action_name
-		else:
-			push_error("Input action not found: ", action_name)
-
+	InputManager.action_pressed.connect(_on_input_action_pressed)
+	
 
 # Set the name of the player based on player_num
 func _set_player_name() -> void:
@@ -56,10 +46,8 @@ func _toggle_ready() -> void:
 	pass
 
 
-# Called at a fixed rate. 'delta' is the elapsed time since the previous frame.
-func _physics_process(_delta: float) -> void:
-	# Check if input action is pressed
-	if Input.is_action_just_pressed(input_mapping["start"]):
+func _on_input_action_pressed(player: int, action: String) -> void:
+	if player != player_num:
+		return  # Ignore input from other players
+	if action == InputManager.INPUT_START:
 		_toggle_ready()
-
-	

--- a/models/player/ready.tscn
+++ b/models/player/ready.tscn
@@ -1,51 +1,15 @@
-[gd_scene load_steps=5 format=3 uid="uid://dvo0oiws54t1m"]
+[gd_scene load_steps=3 format=3 uid="uid://dvo0oiws54t1m"]
 
 [ext_resource type="Script" uid="uid://c2fge45tdrxy1" path="res://models/player/ready.gd" id="1_i5n61"]
 [ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_gkuhg"]
-[ext_resource type="FontFile" uid="uid://bm8bvpfu88aux" path="res://assets/fonts/Montserrat/static/Montserrat-Regular.ttf" id="4_vokxs"]
-[ext_resource type="FontFile" uid="uid://csk5t783aicvv" path="res://assets/fonts/Montserrat/static/Montserrat-ExtraBoldItalic.ttf" id="5_rgc1c"]
 
 [node name="Score" type="Node2D"]
 script = ExtResource("1_i5n61")
 
-[node name="GameTitleText" type="RichTextLabel" parent="."]
-offset_left = -213.0
-offset_top = -9.0
-offset_right = 212.0
-offset_bottom = 63.0
-theme_override_fonts/normal_font = ExtResource("2_gkuhg")
-theme_override_font_sizes/normal_font_size = 40
-text = "BLOCKBUSTERS!"
-horizontal_alignment = 1
-
-[node name="InstructionsText" type="RichTextLabel" parent="."]
-offset_left = -255.0
-offset_top = 73.0
-offset_right = 359.0
-offset_bottom = 204.0
-theme_override_fonts/normal_font = ExtResource("4_vokxs")
-theme_override_font_sizes/normal_font_size = 18
-text = "- Launch a projectile, costs 1 point
-- Blow up the blocks containing gems to free the gems
-- Get a freed gem to your zone, collect it for +2 points
-- Projectile hits a ship, disables it for 3 seconds
-- First player to 10 points wins"
-
-[node name="ReadyText" type="RichTextLabel" parent="."]
-offset_left = -351.0
-offset_top = 230.0
-offset_right = 342.0
-offset_bottom = 275.0
-theme_override_fonts/normal_font = ExtResource("5_rgc1c")
-theme_override_font_sizes/normal_font_size = 18
-text = "Press start to ready up!"
-horizontal_alignment = 1
-
 [node name="PlayerNameText" type="RichTextLabel" parent="."]
 offset_left = -147.0
-offset_top = 287.0
 offset_right = 143.0
-offset_bottom = 341.0
+offset_bottom = 54.0
 theme_override_colors/default_color = Color(1, 1, 1, 1)
 theme_override_fonts/normal_font = ExtResource("2_gkuhg")
 theme_override_font_sizes/normal_font_size = 40

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ Config="*res://global/config.gd"
 Game="*res://global/game.gd"
 Util="*res://global/util.gd"
 AudioManager="*res://global/audio_manager.tscn"
+InputManager="*res://global/input_manager.gd"
 
 [display]
 

--- a/project.godot
+++ b/project.godot
@@ -99,6 +99,12 @@ p2_down={
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":3,"axis_value":1.0,"script":null)
 ]
 }
+p2_action_a={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":true,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":77,"key_label":0,"unicode":109,"location":0,"echo":false,"script":null)
+]
+}
 p2_action_b={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
@@ -109,12 +115,6 @@ p2_start={
 "deadzone": 0.5,
 "events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":3,"pressure":0.0,"pressed":true,"script":null)
-]
-}
-p2_action_a={
-"deadzone": 0.2,
-"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":true,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":77,"key_label":0,"unicode":109,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	Game.player_ready_updated.connect(_on_player_ready_updated)
 	# Game.detect_input_mode()
 	_setup()
-	Game.input_mode_updated.connect(_setup)
+	InputManager.input_mode_updated.connect(_setup)
 
 
 # If both players are ready, start the game
@@ -22,13 +22,13 @@ func _on_player_ready_updated() -> void:
 
 # Setup the UI based on the current input mode		
 func _setup() -> void:
-	match Game.input_mode:
-		Game.InputMode.TABLE:
+	match InputManager.mode:
+		InputManager.Mode.TABLE:
 			$TableMode.show()
 			$CouchMode.hide()
 			$ReadyP1.transform = Transform2D(PI/2, Vector2(122, 291))
 			$ReadyP2.transform = Transform2D(-PI/2, Vector2(906, 288))
-		Game.InputMode.COUCH:
+		InputManager.Mode.COUCH:
 			$TableMode.hide()
 			$CouchMode.show()
 			$ReadyP1.transform = Transform2D(0, Vector2(250, 400))

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -7,7 +7,6 @@ const GAME_START_DELAY_SECONDS: float = 1.0
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	Game.player_ready_updated.connect(_on_player_ready_updated)
-	# Game.detect_input_mode()
 	_setup()
 	InputManager.input_mode_updated.connect(_setup)
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -7,25 +7,35 @@ const GAME_START_DELAY_SECONDS: float = 1.0
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	Game.player_ready_updated.connect(_on_player_ready_updated)
-	_detect_input_mode()
+	# Game.detect_input_mode()
+	_setup()
+	Game.input_mode_updated.connect(_setup)
 
 
 # If both players are ready, start the game
 func _on_player_ready_updated() -> void:
-	if $ReadyPlayer1.is_ready and $ReadyPlayer2.is_ready:
+	if $ReadyP1.is_ready and $ReadyP2.is_ready:
 		await Util.delay(GAME_START_DELAY_SECONDS)
-		if $ReadyPlayer1.is_ready and $ReadyPlayer2.is_ready:
+		if $ReadyP1.is_ready and $ReadyP2.is_ready:
 			_goto_scene("res://scenes/play_game.tscn")
+
+
+# Setup the UI based on the current input mode		
+func _setup() -> void:
+	match Game.input_mode:
+		Game.InputMode.TABLE:
+			$TableMode.show()
+			$CouchMode.hide()
+			$ReadyP1.transform = Transform2D(PI/2, Vector2(122, 291))
+			$ReadyP2.transform = Transform2D(-PI/2, Vector2(906, 288))
+		Game.InputMode.COUCH:
+			$TableMode.hide()
+			$CouchMode.show()
+			$ReadyP1.transform = Transform2D(0, Vector2(250, 400))
+			$ReadyP2.transform = Transform2D(0, Vector2(776, 400))
 
 
 # Goto a scene, guarding against the condition that the tree has been unloaded since the calling thread arrived here
 func _goto_scene(path: String) -> void:
 	if get_tree():
 		get_tree().change_scene_to_file(path)
-
-
-# Detect the input mode (gamepad or keyboard) and update the UI accordingly
-func _detect_input_mode() -> void:
-	var gamepads: Array[int] = Input.get_connected_joypads()
-	if gamepads.size() == 2:
-		Game.activate_dual_gamepad_input_mode()

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -3,12 +3,13 @@ extends Node2D
 # Constants
 const GAME_START_DELAY_SECONDS: float = 1.0
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	Game.player_ready_updated.connect(_on_player_ready_updated)
-	pass
+	_detect_input_mode()
 
-	
+
 # If both players are ready, start the game
 func _on_player_ready_updated() -> void:
 	if $ReadyPlayer1.is_ready and $ReadyPlayer2.is_ready:
@@ -23,3 +24,8 @@ func _goto_scene(path: String) -> void:
 		get_tree().change_scene_to_file(path)
 
 
+# Detect the input mode (gamepad or keyboard) and update the UI accordingly
+func _detect_input_mode() -> void:
+	var gamepads: Array[int] = Input.get_connected_joypads()
+	if gamepads.size() == 2:
+		Game.activate_dual_gamepad_input_mode()

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://cmijftuchxf62"]
+[gd_scene load_steps=4 format=3 uid="uid://cmijftuchxf62"]
 
 [ext_resource type="Script" uid="uid://cnw80skrxjv77" path="res://scenes/main.gd" id="1_0pxjd"]
+[ext_resource type="PackedScene" uid="uid://5830e5k6edcl" path="res://models/player/instructions.tscn" id="3_sugp2"]
 [ext_resource type="PackedScene" uid="uid://dvo0oiws54t1m" path="res://models/player/ready.tscn" id="4_jyhfs"]
 
 [node name="Main" type="Node2D"]
@@ -12,12 +13,28 @@ offset_right = 1024.0
 offset_bottom = 576.0
 color = Color(0, 0, 0, 1)
 
-[node name="ReadyPlayer1" parent="." instance=ExtResource("4_jyhfs")]
-position = Vector2(409, 291)
+[node name="ReadyP1" parent="." instance=ExtResource("4_jyhfs")]
+position = Vector2(122, 291)
 rotation = 1.5708
 player_num = 1
 
-[node name="ReadyPlayer2" parent="." instance=ExtResource("4_jyhfs")]
-position = Vector2(619, 288)
+[node name="ReadyP2" parent="." instance=ExtResource("4_jyhfs")]
+position = Vector2(906, 288)
 rotation = -1.5708
 player_num = 2
+
+[node name="TableMode" type="Node2D" parent="."]
+visible = false
+
+[node name="InstructionsP1" parent="TableMode" instance=ExtResource("3_sugp2")]
+position = Vector2(409, 291)
+rotation = 1.5708
+
+[node name="InstructionsP2" parent="TableMode" instance=ExtResource("3_sugp2")]
+position = Vector2(619, 288)
+rotation = -1.5708
+
+[node name="CouchMode" type="Node2D" parent="."]
+
+[node name="InstructionsC" parent="CouchMode" instance=ExtResource("3_sugp2")]
+position = Vector2(512, 118)

--- a/scenes/play_game.gd
+++ b/scenes/play_game.gd
@@ -23,6 +23,9 @@ var is_game_over: bool                   = false
 func _ready() -> void:
 	started_at_ticks_msec = Time.get_ticks_msec()
 	spawn_next_gem_at_msec = started_at_ticks_msec + Config.GEM_SPAWN_INITIAL_MSEC
+	# Setup the board based on the current input mode
+	_setup()
+	InputManager.input_mode_updated.connect(_setup)
 	# Create the board before resetting the game (so that scores update on the board)
 	_create_board()
 	# Reset the game
@@ -38,6 +41,21 @@ func _ready() -> void:
 	await Util.delay(Config.GAME_START_COUNTER_DELAY)
 	_hide_modal()
 	pass
+
+
+# Setup the UI based on the current input mode		
+func _setup() -> void:
+	match InputManager.mode:
+		InputManager.Mode.TABLE:
+			$PlayerMeta/ScoreP1.transform = Transform2D(PI/2, Vector2(31, 288))
+			$PlayerMeta/EnergyP1.transform = Transform2D(PI/2, Vector2(31, 388))
+			$PlayerMeta/ScoreP2.transform = Transform2D(-PI/2, Vector2(993, 288))
+			$PlayerMeta/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 188))
+		InputManager.Mode.COUCH:
+			$PlayerMeta/ScoreP1.transform = Transform2D(0, Vector2(31, 288))
+			$PlayerMeta/EnergyP1.transform = Transform2D(-PI/2, Vector2(31, 488))
+			$PlayerMeta/ScoreP2.transform = Transform2D(0, Vector2(993, 288))
+			$PlayerMeta/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 488))
 
 
 # Called at a fixed rate. 'delta' is the elapsed time since the previous frame.
@@ -124,7 +142,7 @@ func _check_for_game_over() -> void:
 # Called when a player collects a gem
 func _on_player_collect_gem(_player_num: int) -> void:
 	gem_dont_spawn_until_ticks_msec = Time.get_ticks_msec() + Config.GEM_SPAWN_AFTER_SCORING_DELAY_MSEC
-	print ("[GAME] Player collected a gem, not spawning another until: ", gem_dont_spawn_until_ticks_msec)
+	print ("[GAME] Player collected a gem")
 
 
 # Create the board with blocks and gems, and spawn player homes, ships, and scores

--- a/scenes/play_game.tscn
+++ b/scenes/play_game.tscn
@@ -125,22 +125,22 @@ player_num = 2
 [node name="PlayerMeta" type="Node2D" parent="."]
 z_index = -1
 
-[node name="P1 Score" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
+[node name="ScoreP1" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
 position = Vector2(31, 288)
 rotation = 1.5708
 player_num = 1
 
-[node name="P1 LaserCharge" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
+[node name="EnergyP1" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
 position = Vector2(31, 388)
 rotation = 1.5708
 player_num = 1
 
-[node name="P2 Score" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
+[node name="ScoreP2" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
 position = Vector2(993, 288)
 rotation = -1.5708
 player_num = 2
 
-[node name="P2 LaserCharge" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
+[node name="EnergyP2" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
 position = Vector2(993, 188)
 rotation = -1.5708
 player_num = 2


### PR DESCRIPTION
- Gamepad controls assume separate Player 1 and Player 2 gamepads (each player's gamepad only controls their own ship)
- When two gamepads are connected, views orient towards couch / regular console screen
  - Main screen title and instructions singular and oriented top-up
  - Player scores oriented top-up
  - Laser energy meters both appear on bottom of screen, so view is symmetrical left/right
- Gamepad joysticks pilot ships at any angle - analog stick, not arcade D-pad

Closes #126