### PR TITLE
Main screen, each player start says "press start"

### DIFF
--- a/global/input_manager.gd
+++ b/global/input_manager.gd
@@ -1,4 +1,4 @@
-﻿extends Node
+extends Node
 
 # Signals
 signal input_mode_updated
@@ -23,7 +23,7 @@ func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
 	var joypads: Array = Input.get_connected_joypads()
 	if joypads.size() >= 2:
 		print ("[GAME] Activating dual gamepad input mode")
-		mode = Mode.COUCH
+		mode = Mode.TABLE # todo go back mode = Mode.COUCH
 		joypads.sort()  # lowest id first for stability
 		# Optionally: dedupe "ghost" XInput mirrors by GUID/name here.
 		p1_device_id = joypads[0]

--- a/models/player/ready.gd
+++ b/models/player/ready.gd
@@ -40,8 +40,10 @@ func _toggle_ready() -> void:
 	_set_color()
 	if is_ready:
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.PLAYER_1_READY if player_num == 0 else SoundEffectSetting.SOUND_EFFECT_TYPE.PLAYER_2_READY)
+		$PressStartText.hide()
 	else:
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.PLAYER_UNREADY)
+		$PressStartText.show()
 	Game.player_ready_updated.emit()
 	pass
 

--- a/models/player/ready.tscn
+++ b/models/player/ready.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dvo0oiws54t1m"]
+[gd_scene load_steps=4 format=3 uid="uid://dvo0oiws54t1m"]
 
 [ext_resource type="Script" uid="uid://c2fge45tdrxy1" path="res://models/player/ready.gd" id="1_i5n61"]
 [ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_gkuhg"]
+[ext_resource type="FontFile" uid="uid://bb8u5b7rplwdy" path="res://assets/fonts/Montserrat/static/Montserrat-Bold.ttf" id="3_1rfpl"]
 
 [node name="Score" type="Node2D"]
 script = ExtResource("1_i5n61")
@@ -16,3 +17,21 @@ theme_override_font_sizes/normal_font_size = 40
 text = "Player #"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="PressStartText" type="RichTextLabel" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -100.0
+offset_top = 55.0
+offset_right = 100.0
+offset_bottom = 85.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_fonts/normal_font = ExtResource("3_1rfpl")
+theme_override_font_sizes/normal_font_size = 18
+text = "PRESS START"
+horizontal_alignment = 1


### PR DESCRIPTION
- On main screen, player start says "press start" under each Player # status in the player's color
- "press start" disappears when player readies up
- "press start" re-appears when player un-readies
- Table mode layout
- Couch mode layout

Closes #146