### PR TITLE
When ship is disabled, player HUD also appears disabled

### DIFF
--- a/global/constant.gd
+++ b/global/constant.gd
@@ -8,6 +8,7 @@ const PLAYER_COLORS: Dictionary = {
 								  }
 #
 # player ship threshold that's rotation only (strafe) before applying force
+const PLAYER_HUD_DISABLED_ALPHA                         = 0.2
 const PLAYER_INPUT_JOYSTICK_DEADZONE: float             = 0.25
 const PLAYER_INVENTORY_MAX_ITEMS: int                   = 2
 const PLAYER_SCORE_COLLECT_GEM_VALUE: int               = 1

--- a/global/game.gd
+++ b/global/game.gd
@@ -7,6 +7,7 @@ signal player_inventory_updated()
 signal player_did_launch_projectile(player_num: int)
 signal player_did_collect_gem(player_num: int)
 signal player_did_harm(player_num: int)
+signal player_enabled(player_num: int, enabled: bool)
 signal projectile_count_updated
 signal player_ready_updated
 signal player_laser_charge_updated(player_num: int, charge_sec: float)
@@ -56,6 +57,7 @@ func _ready() -> void:
 	projectile_count_updated.connect(_on_projectile_count_updated)
 	player_ready_updated.connect(_on_player_ready_updated)
 	player_laser_charge_updated.connect(_on_player_laser_charge_updated)
+	player_enabled.connect(_on_player_enabled)
 
 
 func _do_reset_game() -> void:
@@ -99,6 +101,10 @@ func _on_player_ready_updated() -> void:
 
 
 func _on_player_laser_charge_updated(_player_num: int, _charge_sec: float ) -> void:
+	pass
+
+
+func _on_player_enabled(_player_num: int, _enabled: bool) -> void:
 	pass
 
 

--- a/models/player/ship.gd
+++ b/models/player/ship.gd
@@ -56,6 +56,7 @@ func do_disable(responsible_player_num: int) -> void:
 	_set_colors(Constant.PLAYER_SHIP_DISABLED_S_RATIO, Constant.PLAYER_SHIP_DISABLED_V_RATIO)
 	_do_deactivate_laser()
 	Game.player_did_harm.emit(responsible_player_num)
+	Game.player_enabled.emit(player_num, false)
 	# Play sound effect
 	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.SHIP_DISABLED)
 
@@ -65,6 +66,7 @@ func do_enable() -> void:
 	is_disabled = false
 	disabled_until_ticks_msec = 0.0
 	_set_colors(1.0)
+	Game.player_enabled.emit(player_num, true)
 	# Play sound effect
 	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.SHIP_REENABLED)
 

--- a/scenes/play_game.gd
+++ b/scenes/play_game.gd
@@ -35,6 +35,7 @@ func _ready() -> void:
 	Game.player_score_updated.connect(_check_for_game_over)
 	Game.projectile_count_updated.connect(_check_for_game_over)
 	Game.player_did_collect_gem.connect(_on_player_collect_gem)
+	Game.player_enabled.connect(_on_player_enabled)
 	# Countdown and then start the game
 	_pause_game()
 	_show_banner(0, "READY...", "SET...")
@@ -47,19 +48,19 @@ func _ready() -> void:
 func _setup() -> void:
 	match InputManager.mode:
 		InputManager.Mode.TABLE:
-			$PlayerMeta/ScoreP1.transform = Transform2D(PI/2, Vector2(31, 288))
-			$PlayerMeta/EnergyP1.transform = Transform2D(PI/2, Vector2(31, 388))
-			$PlayerMeta/InventoryP1.transform = Transform2D(PI/2, Vector2(31, 88))
-			$PlayerMeta/ScoreP2.transform = Transform2D(-PI/2, Vector2(993, 288))
-			$PlayerMeta/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 188))
-			$PlayerMeta/InventoryP2.transform = Transform2D(-PI/2, Vector2(993, 488))
+			$HudPlayer1/ScoreP1.transform = Transform2D(PI/2, Vector2(31, 288))
+			$HudPlayer1/EnergyP1.transform = Transform2D(PI/2, Vector2(31, 388))
+			$HudPlayer1/InventoryP1.transform = Transform2D(PI/2, Vector2(31, 88))
+			$HudPlayer2/ScoreP2.transform = Transform2D(-PI/2, Vector2(993, 288))
+			$HudPlayer2/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 188))
+			$HudPlayer2/InventoryP2.transform = Transform2D(-PI/2, Vector2(993, 488))
 		InputManager.Mode.COUCH:
-			$PlayerMeta/ScoreP1.transform = Transform2D(0, Vector2(31, 288))
-			$PlayerMeta/EnergyP1.transform = Transform2D(-PI/2, Vector2(31, 488))
-			$PlayerMeta/InventoryP1.transform = Transform2D(PI/2, Vector2(31, 88))
-			$PlayerMeta/ScoreP2.transform = Transform2D(0, Vector2(993, 288))
-			$PlayerMeta/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 488))
-			$PlayerMeta/InventoryP2.transform = Transform2D(PI/2, Vector2(1, -1), 0, Vector2(993, 88))
+			$HudPlayer1/ScoreP1.transform = Transform2D(0, Vector2(31, 288))
+			$HudPlayer1/EnergyP1.transform = Transform2D(-PI/2, Vector2(31, 488))
+			$HudPlayer1/InventoryP1.transform = Transform2D(PI/2, Vector2(31, 88))
+			$HudPlayer2/ScoreP2.transform = Transform2D(0, Vector2(993, 288))
+			$HudPlayer2/EnergyP2.transform = Transform2D(-PI/2, Vector2(993, 488))
+			$HudPlayer2/InventoryP2.transform = Transform2D(PI/2, Vector2(1, -1), 0, Vector2(993, 88))
 
 
 # Called at a fixed rate. 'delta' is the elapsed time since the previous frame.
@@ -156,6 +157,15 @@ func _on_player_collect_gem(player_num: int) -> void:
 	else:
 		gem_dont_spawn_until_ticks_msec = Time.get_ticks_msec() + 999999	
 	print ("[GAME] Player collected a gem")
+
+
+# When ship is disabled, player HUD also appears disabled #155
+func _on_player_enabled(player_num: int, enabled: bool) -> void:
+	match player_num:
+		1:
+			$HudPlayer1.modulate.a = 1 if enabled else Constant.PLAYER_HUD_DISABLED_ALPHA
+		2:
+			$HudPlayer2.modulate.a = 1 if enabled else Constant.PLAYER_HUD_DISABLED_ALPHA
 
 
 # Create the board with blocks and gems, and spawn player homes, ships, and scores

--- a/scenes/play_game.tscn
+++ b/scenes/play_game.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=9 format=3 uid="uid://bgvuuvhomj1ox"]
+[gd_scene load_steps=8 format=3 uid="uid://bgvuuvhomj1ox"]
 
 [ext_resource type="Script" uid="uid://b3ywa5gtd7j2q" path="res://scenes/play_game.gd" id="1_s826b"]
-[ext_resource type="FontFile" uid="uid://dblvrdtyp1jsa" path="res://assets/fonts/Montserrat/static/Montserrat-Black.ttf" id="2_4xfa0"]
 [ext_resource type="PackedScene" uid="uid://cxjls2n6gleb4" path="res://models/player/home.tscn" id="3_466yg"]
 [ext_resource type="PackedScene" uid="uid://b8eby70l6c6qs" path="res://models/hud/hud_score.tscn" id="3_bgg7l"]
 [ext_resource type="PackedScene" uid="uid://rpl4j57m2rt4" path="res://models/hud/hud_laser_charge.tscn" id="4_sbpvv"]
@@ -91,41 +90,6 @@ offset_right = 1024.0
 offset_bottom = 576.0
 color = Color(0.1, 0.1, 0.1, 1)
 
-[node name="Modal" type="Node2D" parent="."]
-visible = false
-z_index = 100
-
-[node name="Text1" type="RichTextLabel" parent="Modal"]
-offset_left = 512.0
-offset_right = 1088.0
-offset_bottom = 512.0
-rotation = 1.5708
-theme_override_colors/default_color = Color(1, 1, 1, 1)
-theme_override_fonts/normal_font = ExtResource("2_4xfa0")
-theme_override_font_sizes/normal_font_size = 40
-text = "Get Ready! "
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Text2" type="RichTextLabel" parent="Modal"]
-offset_left = 512.0
-offset_top = 576.0
-offset_right = 1088.0
-offset_bottom = 1088.0
-rotation = -1.5708
-theme_override_colors/default_color = Color(1, 1, 1, 1)
-theme_override_fonts/normal_font = ExtResource("2_4xfa0")
-theme_override_font_sizes/normal_font_size = 40
-text = "Get Ready! "
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Base" type="ColorRect" parent="Modal"]
-z_index = -10
-offset_right = 1024.0
-offset_bottom = 576.0
-color = Color(0, 0, 0, 0.501961)
-
 [node name="HomePlayer1" parent="." instance=ExtResource("3_466yg")]
 z_index = -1
 position = Vector2(512, 0)
@@ -136,35 +100,37 @@ z_index = -1
 position = Vector2(512, 576)
 player_num = 2
 
-[node name="PlayerMeta" type="Node2D" parent="."]
+[node name="HudPlayer1" type="Node2D" parent="."]
 z_index = 10
 
-[node name="ScoreP1" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
+[node name="ScoreP1" parent="HudPlayer1" instance=ExtResource("3_bgg7l")]
 position = Vector2(31, 288)
 rotation = 1.5708
 player_num = 1
 
-[node name="EnergyP1" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
+[node name="EnergyP1" parent="HudPlayer1" instance=ExtResource("4_sbpvv")]
 position = Vector2(31, 388)
 rotation = 1.5708
 player_num = 1
 
-[node name="InventoryP1" parent="PlayerMeta" instance=ExtResource("6_xugar")]
+[node name="InventoryP1" parent="HudPlayer1" instance=ExtResource("6_xugar")]
 position = Vector2(31, 88)
 rotation = 1.5708
 player_num = 1
 
-[node name="ScoreP2" parent="PlayerMeta" instance=ExtResource("3_bgg7l")]
+[node name="HudPlayer2" type="Node2D" parent="."]
+
+[node name="ScoreP2" parent="HudPlayer2" instance=ExtResource("3_bgg7l")]
 position = Vector2(993, 288)
 rotation = -1.5708
 player_num = 2
 
-[node name="EnergyP2" parent="PlayerMeta" instance=ExtResource("4_sbpvv")]
+[node name="EnergyP2" parent="HudPlayer2" instance=ExtResource("4_sbpvv")]
 position = Vector2(993, 188)
 rotation = -1.5708
 player_num = 2
 
-[node name="InventoryP2" parent="PlayerMeta" instance=ExtResource("6_xugar")]
+[node name="InventoryP2" parent="HudPlayer2" instance=ExtResource("6_xugar")]
 position = Vector2(993, 488)
 rotation = -1.5708
 player_num = 2


### PR DESCRIPTION
When a ship is disabled, change the colors of the player HUD on their side (score, energy, inventory) to appear desaturated/faded the same as the ship itself.

Closes #155