### PR TITLE
Projectile additional pick-ups spawn in blocks

### DIFF
--- a/global/constant.gd
+++ b/global/constant.gd
@@ -48,18 +48,19 @@ const BLOCK_HALF_BREAK_APART_VELOCITY: float       = BLOCK_BREAK_APART_VELOCITY 
 const BLOCK_HALF_HEATED_BREAK_SEC: float           = BLOCK_HEATED_BREAK_SEC / 2
 const BLOCK_HEATED_BREAK_SEC: float                = 0.5
 const BLOCK_INACTIVE_OPACITY: float                = 0.25
-const BLOCK_INNER_GEM_ALPHA: float                 = 0.8
+const BLOCK_INNER_ITEM_ALPHA: float                = 0.8
 const BLOCK_LINEAR_DAMP: float                     = 0.1
 const BLOCK_QUART_HEATED_BREAK_SEC: float          = BLOCK_HEATED_BREAK_SEC / 4
 #
 # gem behavior
 const GEM_MAX_COUNT: int                      = 1
 const PICKUP_MAX_COUNT: int                   = 1
-const GEM_SPAWN_EVERY_MSEC: int               = 100 # delay between spawning gems
+const GEM_SPAWN_EVERY_SEC: float               = 0.1 # delay between spawning gems
 const GEM_SPAWN_AFTER_SCORING_DELAY_MSEC: int = 1500 # delay after scoring before spawning a new gem
 #
 # pickup spawn behavior
-const PICKUP_SPAWN_EVERY_MSEC: int = 5_000 # delay between spawning pickups
+const PICKUP_SPAWN_INITIAL_SEC: float = 3.0 # delay before spawning the first pickup
+const PICKUP_SPAWN_EVERY_SEC: float = 5.0 # delay between spawning pickups
 #
 # game behavior
 const SHOW_MODAL_SEC: float = 4.0
@@ -71,9 +72,9 @@ const PROJECTILE_EXPLOSIVE_INITIAL_VELOCITY: float = 200.0
 const PROJECTILE_EXPLOSIVE_MAX_VELOCITY: float     = 2000.0
 #
 # pertaining to explosive
-const EXPLOSION_FORCE: int               = 8000
-const EXPLOSION_HEAT_RADIUS_RATIO: float = 0.6
-const EXPLOSION_LIFETIME_MSEC: int       = 1000
+const EXPLOSION_FORCE: int                    = 8000
+const EXPLOSION_HEAT_RADIUS_RATIO: float      = 0.6
+const EXPLOSION_LIFETIME_MSEC: int            = 1000
 const EXPLOSION_SHIP_EFFECT_MULTIPLIER: float = 0.8 # ratio multiplied by ship overheating threshold
 #
 # pertaining to heat

--- a/global/constant.gd
+++ b/global/constant.gd
@@ -54,8 +54,12 @@ const BLOCK_QUART_HEATED_BREAK_SEC: float          = BLOCK_HEATED_BREAK_SEC / 4
 #
 # gem behavior
 const GEM_MAX_COUNT: int                      = 1
+const PICKUP_MAX_COUNT: int                   = 1
 const GEM_SPAWN_EVERY_MSEC: int               = 100 # delay between spawning gems
 const GEM_SPAWN_AFTER_SCORING_DELAY_MSEC: int = 1500 # delay after scoring before spawning a new gem
+#
+# pickup spawn behavior
+const PICKUP_SPAWN_EVERY_MSEC: int = 5_000 # delay between spawning pickups
 #
 # game behavior
 const SHOW_MODAL_SEC: float = 4.0

--- a/global/game.gd
+++ b/global/game.gd
@@ -14,6 +14,7 @@ signal player_laser_charge_updated(player_num: int, charge_sec: float)
 # Group names
 const BLOCK_GROUP: StringName = "BlockGroup"
 const GEM_GROUP: StringName   = "GemGroup"
+const PICKUP_GROUP: StringName = "PickupGroup"
 # Enum for whether Player 1 wins, Player 2 wins, or a draw
 enum Result {
 	PLAYER_1_WINS,

--- a/global/game.gd
+++ b/global/game.gd
@@ -6,6 +6,7 @@ signal player_score_updated()
 signal player_inventory_updated()
 signal player_did_launch_projectile(player_num: int)
 signal player_did_collect_gem(player_num: int)
+signal player_did_collect_item(player_num: int, type: InventoryItemType)
 signal player_did_harm(player_num: int)
 signal player_enabled(player_num: int, enabled: bool)
 signal projectile_count_updated
@@ -48,7 +49,12 @@ func player_can_launch_projectile(player_num: int) -> bool:
 		if player_inventory_item == InventoryItemType.PROJECTILE:
 			return true
 	return false
-		
+
+	
+# Check if the player has room in their inventory for a new item
+func player_can_add_item(player_num: int) -> bool:
+	return len(player_inventory[player_num]) < Constant.PLAYER_INVENTORY_MAX_ITEMS
+
 
 func _ready() -> void:
 	reset_game.connect(_do_reset_game)
@@ -59,6 +65,7 @@ func _ready() -> void:
 	player_ready_updated.connect(_on_player_ready_updated)
 	player_laser_charge_updated.connect(_on_player_laser_charge_updated)
 	player_enabled.connect(_on_player_enabled)
+	player_did_collect_item.connect(_on_player_did_collect_item)
 
 
 func _do_reset_game() -> void:
@@ -107,7 +114,13 @@ func _on_player_laser_charge_updated(_player_num: int, _charge_sec: float ) -> v
 
 func _on_player_enabled(_player_num: int, _enabled: bool) -> void:
 	pass
+	
 
+func _on_player_did_collect_item(player_num: int, type: InventoryItemType) -> void:
+	print("[GAME] Player %d collected pickup: %s" % [player_num, type])
+	player_inventory[player_num].append(type)
+	player_inventory_updated.emit()
+	pass
 
 func _player_inventory_remove(player_num: int, item: InventoryItemType) -> void:
 	var new_inventory = [];

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -4,9 +4,10 @@ extends Heatable
 # Variables
 var item: Node = null
 # Preloaded scenes
-const half1_scene: PackedScene = preload("res://models/block/block_half_1.tscn")
-const half2_scene: PackedScene = preload("res://models/block/block_half_2.tscn")
-const gem_scene: PackedScene   = preload("res://models/gem/gem.tscn")
+const half1_scene: PackedScene             = preload("res://models/block/block_half_1.tscn")
+const half2_scene: PackedScene             = preload("res://models/block/block_half_2.tscn")
+const gem_scene: PackedScene               = preload("res://models/gem/gem.tscn")
+const pickup_projectile_scene: PackedScene = preload("res://models/pickup/pickup_projectile.tscn")
 # Whether this block has a gem
 @export var has_gem: bool = false
 
@@ -54,13 +55,23 @@ func add_gem() -> void:
 	item.position = Vector2(0, 0)
 	item.add_collision_exception_with(self)
 	item.freeze = true
-	item.modulate.a = Constant.BLOCK_INNER_GEM_ALPHA
+	item.modulate.a = Constant.BLOCK_INNER_ITEM_ALPHA
 	self.add_child(item)
 	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.GAME_START)
 
-# Adds a pickup inside this block
+
+# Adds a pickup inside this block -- currently only projectiles
 func add_pickup() -> void:
-	pass
+	$ParticleEmitter.emitting = true
+	item = pickup_projectile_scene.instantiate()
+	item.position = Vector2(0, 0)
+	item.add_collision_exception_with(self)
+	item.freeze = true
+	item.modulate.a = Constant.BLOCK_INNER_ITEM_ALPHA
+	self.add_child(item)
+	# sound is currently the same as gem addition
+	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.GAME_START)
+
 
 # Break the block apart into two halves
 func do_break() -> void:
@@ -97,6 +108,7 @@ func _do_release_item() -> bool:
 		item.freeze = false
 		item.reparent(self.get_parent())
 		item.add_collision_exception_with(self)
+		item.modulate.a = 1.0
 		item.position = position
 		item.linear_velocity = linear_velocity
 		return true

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -2,7 +2,7 @@ class_name Block
 extends Heatable
 
 # Variables
-var gem: Node = null
+var item: Node = null
 # Preloaded scenes
 const half1_scene: PackedScene = preload("res://models/block/block_half_1.tscn")
 const half2_scene: PackedScene = preload("res://models/block/block_half_2.tscn")
@@ -36,9 +36,9 @@ func _ready() -> void:
 
 
 # When a gem can be added
-func can_add_gem() -> bool:
+func can_add_item() -> bool:
 	# If the block already has a gem, return false
-	if gem:
+	if item:
 		return false
 	# If the block is unfrozen, return false
 	if not freeze:
@@ -50,14 +50,17 @@ func can_add_gem() -> bool:
 # Adds a gem inside this block
 func add_gem() -> void:
 	$ParticleEmitter.emitting = true
-	gem = gem_scene.instantiate()
-	gem.position = Vector2(0, 0)
-	gem.add_collision_exception_with(self)
-	gem.freeze = true
-	gem.modulate.a = Constant.BLOCK_INNER_GEM_ALPHA
-	self.add_child(gem)
+	item = gem_scene.instantiate()
+	item.position = Vector2(0, 0)
+	item.add_collision_exception_with(self)
+	item.freeze = true
+	item.modulate.a = Constant.BLOCK_INNER_GEM_ALPHA
+	self.add_child(item)
 	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.GAME_START)
 
+# Adds a pickup inside this block
+func add_pickup() -> void:
+	pass
 
 # Break the block apart into two halves
 func do_break() -> void:
@@ -72,9 +75,9 @@ func do_break() -> void:
 	half2.linear_velocity = linear_velocity + Vector2(Constant.BLOCK_BREAK_APART_VELOCITY, Constant.BLOCK_BREAK_APART_VELOCITY)
 	half2.half_num = 2
 	# If the block has a gem, release it, and play the sound effect depending on whether there was a gem or not
-	if _do_release_gem():
-		gem.add_collision_exception_with(half1)
-		gem.add_collision_exception_with(half2)
+	if _do_release_item():
+		item.add_collision_exception_with(half1)
+		item.add_collision_exception_with(half2)
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.BLOCK_BREAK_HALF_GEM)
 	else:
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.BLOCK_BREAK_HALF_NOGEM)
@@ -89,15 +92,12 @@ func do_break() -> void:
 	self.call_deferred("queue_free")
 
 
-func _do_release_gem() -> bool:
-	# Gem
-	if gem:
-		gem.queue_free()
-		gem = gem_scene.instantiate()
-		gem.position = position
-		gem.linear_velocity = linear_velocity
-		gem.add_collision_exception_with(self)
-		self.get_parent().call_deferred("add_child", gem)
+func _do_release_item() -> bool:
+	if item:
+		item.reparent(self.get_parent())
+		item.add_collision_exception_with(self)
+		item.position = position
+		item.linear_velocity = linear_velocity
 		return true
 	return false
 

--- a/models/block/block.gd
+++ b/models/block/block.gd
@@ -94,6 +94,7 @@ func do_break() -> void:
 
 func _do_release_item() -> bool:
 	if item:
+		item.freeze = false
 		item.reparent(self.get_parent())
 		item.add_collision_exception_with(self)
 		item.position = position

--- a/models/hud/hud_banner.gd
+++ b/models/hud/hud_banner.gd
@@ -26,5 +26,5 @@ func _ready() -> void:
 	
 
 # Called when the animation is finished
-func _on_animation_finished(anim_name: String) -> void:
+func _on_animation_finished(_anim_name: String) -> void:
 	call_deferred("queue_free")

--- a/models/pickup/pickup.gd
+++ b/models/pickup/pickup.gd
@@ -1,0 +1,11 @@
+class_name Pickup
+extends Collidable
+
+
+@export var type : Game.InventoryItemType = Game.InventoryItemType.EMPTY
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	add_to_group(Game.PICKUP_GROUP)
+	pass

--- a/models/pickup/pickup.gd.uid
+++ b/models/pickup/pickup.gd.uid
@@ -1,0 +1,1 @@
+uid://cttgqsa2g5l70

--- a/models/pickup/pickup_projectile.gd
+++ b/models/pickup/pickup_projectile.gd
@@ -1,0 +1,8 @@
+class_name PickupProjectile
+extends Pickup
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	type = Game.InventoryItemType.PROJECTILE
+	super._ready()

--- a/models/pickup/pickup_projectile.gd.uid
+++ b/models/pickup/pickup_projectile.gd.uid
@@ -1,0 +1,1 @@
+uid://dgibky2mluyx3

--- a/models/pickup/pickup_projectile.tscn
+++ b/models/pickup/pickup_projectile.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=5 format=3 uid="uid://bl2llq48pq3cr"]
+
+[ext_resource type="PhysicsMaterial" uid="uid://dw07h3wvuqaey" path="res://models/gem/gem.tres" id="1_4v1y3"]
+[ext_resource type="Script" uid="uid://dgibky2mluyx3" path="res://models/pickup/pickup_projectile.gd" id="2_u62ke"]
+[ext_resource type="Shader" uid="uid://eqs0ghv7w8u6" path="res://shaders/circle_filled.gdshader" id="3_r6o0i"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_r6o0i"]
+shader = ExtResource("3_r6o0i")
+shader_parameter/color = Color(1, 1, 1, 0.294118)
+shader_parameter/diameter = 1.0
+
+[node name="PickupProjectile" type="RigidBody2D"]
+mass = 3.0
+physics_material_override = ExtResource("1_4v1y3")
+gravity_scale = 0.0
+contact_monitor = true
+max_contacts_reported = 1
+script = ExtResource("2_u62ke")
+metadata/_edit_vertical_guides_ = [10.0]
+
+[node name="TriangleLight" type="Polygon2D" parent="."]
+position = Vector2(1.99997, 20)
+rotation = -1.57079
+polygon = PackedVector2Array(12, -6, 22, -7, 29, -2, 12, -2)
+
+[node name="TriangleDark" type="Polygon2D" parent="."]
+position = Vector2(1.99997, 20)
+rotation = -1.57079
+color = Color(0.73, 0.73, 0.73, 1)
+polygon = PackedVector2Array(12, -2, 29, -2, 22, 3, 12, 2)
+
+[node name="ColorRect" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_r6o0i")
+offset_left = -10.0
+offset_top = -10.0
+offset_right = 10.0
+offset_bottom = 10.0
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
+visible = false
+polygon = PackedVector2Array(10, 0, 9, 4, 7, 7, 4, 9, 0, 10, -4, 9, -7, 7, -9, 4, -10, 0, -9, -4, -7, -7, -4, -9, 0, -10, 4, -9, 7, -7, 9, -4)

--- a/models/player/ship.gd
+++ b/models/player/ship.gd
@@ -339,6 +339,13 @@ func _on_collision(body: Node2D) -> void:
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.SHIP_COLLIDES_WITH_BLOCK_QUART)
 	elif body is Gem:
 		AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.SHIP_COLLIDES_WITH_GEM)
+	elif body is Pickup:
+		if Game.player_can_add_item(player_num):
+			# FUTURE: AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.SHIP_COLLIDES_WITH_PICKUP)
+			Game.player_did_collect_item.emit(player_num, body.type)
+			body.queue_free()
+		# FUTURE else:
+		# 	AudioManager.create_2d_audio_at_location(global_position, SoundEffectSetting.SOUND_EFFECT_TYPE.PICKUP_FAIL)
 
 
 # Called when another body enters the forcefield area

--- a/scenes/play_game.gd
+++ b/scenes/play_game.gd
@@ -1,10 +1,10 @@
 extends Node2D
 
 # Preloaded Scenes
-const ship_scene: PackedScene  = preload('res://models/player/ship.tscn')
-const home_scene: PackedScene  = preload('res://models/player/home.tscn')
-const score_scene: PackedScene = preload('res://models/hud/hud_score.tscn')
-const block_scene: PackedScene = preload('res://models/block/block.tscn')
+const ship_scene: PackedScene   = preload('res://models/player/ship.tscn')
+const home_scene: PackedScene   = preload('res://models/player/home.tscn')
+const score_scene: PackedScene  = preload('res://models/hud/hud_score.tscn')
+const block_scene: PackedScene  = preload('res://models/block/block.tscn')
 const banner_scene: PackedScene = preload('res://models/hud/hud_banner.tscn')
 # References to player homes
 @onready var player_home_1 = $HomePlayer1
@@ -16,7 +16,7 @@ var mesh: Dictionary                     = {}
 var block_count: int                     = 0
 var started_at_ticks_msec: int           = 0
 var spawn_next_gem_at_msec: int          = 0
-var spawn_next_pickup_at_msec: int   = 0
+var spawn_next_pickup_at_msec: int       = 0
 var gem_dont_spawn_until_ticks_msec: int = 0
 var is_game_over: bool                   = false
 
@@ -25,7 +25,7 @@ var is_game_over: bool                   = false
 func _ready() -> void:
 	started_at_ticks_msec = Time.get_ticks_msec()
 	spawn_next_gem_at_msec = started_at_ticks_msec + int(Constant.SHOW_MODAL_SEC * 1000)
-	spawn_next_pickup_at_msec = started_at_ticks_msec + int(Constant.PICKUP_SPAWN_EVERY_MSEC)
+	spawn_next_pickup_at_msec = spawn_next_gem_at_msec + int(Constant.PICKUP_SPAWN_INITIAL_SEC * 1000)
 	# Setup the board based on the current input mode
 	_setup()
 	InputManager.input_mode_updated.connect(_setup)
@@ -69,11 +69,11 @@ func _setup() -> void:
 func _physics_process(_delta: float) -> void:
 	# Check if it's time to spawn a gem
 	if Time.get_ticks_msec() >= spawn_next_gem_at_msec:
-		spawn_next_gem_at_msec = Time.get_ticks_msec() + Constant.GEM_SPAWN_EVERY_MSEC
+		spawn_next_gem_at_msec = Time.get_ticks_msec() + int(Constant.GEM_SPAWN_EVERY_SEC * 1000)
 		_spawn_gem()
 	# Check if it's time to spawn a pickup
 	if Time.get_ticks_msec() >= spawn_next_pickup_at_msec:
-		spawn_next_pickup_at_msec = Time.get_ticks_msec() + Constant.PICKUP_SPAWN_EVERY_MSEC
+		spawn_next_pickup_at_msec = Time.get_ticks_msec() + int(Constant.PICKUP_SPAWN_EVERY_SEC * 1000)
 		_spawn_pickup()
 	pass
 
@@ -96,7 +96,7 @@ func _game_over(result: Game.Result) -> void:
 
 
 # Spawn a banner at the given position
-func _show_banner(player_num: int, message:String, message_2:String = "") -> void:
+func _show_banner(player_num: int, message: String, message_2: String = "") -> void:
 	var viewport_size: Vector2 = get_viewport().get_visible_rect().size
 	match InputManager.mode:
 		InputManager.Mode.COUCH:
@@ -105,11 +105,12 @@ func _show_banner(player_num: int, message:String, message_2:String = "") -> voi
 			_spawn_banner(player_num, viewport_size.x * 0.75, viewport_size.y / 2, -90, 0.6, message, message_2)
 			_spawn_banner(player_num, viewport_size.x * 0.25, viewport_size.y / 2, 90, 0.6, message, message_2)
 
+
 # Spawn a banner at the given position
-func _spawn_banner(player_num: int, x: float, y:float, _rotation_degrees:float, _scale:float, message:String, message_2: String = "") -> void:
-	var banner: Node        = banner_scene.instantiate()
+func _spawn_banner(player_num: int, x: float, y: float, _rotation_degrees: float, _scale: float, message: String, message_2: String = "") -> void:
+	var banner: Node = banner_scene.instantiate()
 	banner.scale = Vector2(_scale, _scale)
-	banner.position = Vector2(x,y)
+	banner.position = Vector2(x, y)
 	banner.rotation_degrees = _rotation_degrees
 	banner.player_num = player_num
 	banner.message = message
@@ -161,7 +162,7 @@ func _on_player_collect_gem(player_num: int) -> void:
 		gem_dont_spawn_until_ticks_msec = Time.get_ticks_msec() + Constant.GEM_SPAWN_AFTER_SCORING_DELAY_MSEC
 		_show_banner(player_num, "GOOOAAAAL!")
 	else:
-		gem_dont_spawn_until_ticks_msec = Time.get_ticks_msec() + 999999	
+		gem_dont_spawn_until_ticks_msec = Time.get_ticks_msec() + 999999
 	print ("[GAME] Player collected a gem")
 
 
@@ -265,7 +266,7 @@ func _spawn_pickup() -> void:
 	else:
 		_check_for_game_over()
 
-	
+
 # Get a random block that may have something added to it
 func _get_block_spawn_candidate() -> Block:
 	var candidates: Array[Block]

--- a/shaders/circle_filled.gdshader
+++ b/shaders/circle_filled.gdshader
@@ -1,0 +1,11 @@
+shader_type canvas_item;
+uniform vec4 color : source_color = vec4(1.0);
+uniform float diameter = 1.0; // Circle Diameter
+
+void fragment() {
+  vec2 pos = UV - vec2(0.5);
+  float outer_radius = diameter / 2.0;
+  float inside_circle = step(length(pos), outer_radius);
+
+  COLOR = vec4(color.rgb, inside_circle * color.a);
+}

--- a/shaders/circle_filled.gdshader.uid
+++ b/shaders/circle_filled.gdshader.uid
@@ -1,0 +1,1 @@
+uid://eqs0ghv7w8u6


### PR DESCRIPTION
- Sometimes a projectile Pickup Item is spawned inside an inactive block - when that block is broken open, the pickup item is released onto the board. The pickup item behaves exactly like a gem, except that what a player touches the item, that player gains the pickup item, e.g. +1 projectile
- Player has a maximum of two projectiles.  There are always just two slots for projectiles, and each slot is either filled (full bright player color) or faint transparent shadow (showing that there used to be a projectile in that inventory slot). Player cannot pick up an additional projectile if they already have two. In that case, the pickup item bounces off their ship just like a gem.
- Pickup item cannot spawn in a block that contains a gem
- Gem cannot spawn in a block that already contains a pickup item
- extends #139 

Closes #143